### PR TITLE
Implement OTLP Logs ingestion

### DIFF
--- a/examples/otel-collector-config.yaml
+++ b/examples/otel-collector-config.yaml
@@ -1,4 +1,16 @@
 receivers:
+  # Generate synthetic logs for testing
+  filelog:
+    include: ["examples/test-logs/*.log"]
+    start_at: beginning
+    operators:
+      - type: json_parser
+        id: json_parser
+        output: extract_timestamp_parser
+      - type: time_parser
+        id: extract_timestamp_parser
+        parse_from: attributes.timestamp
+        layout: '%Y-%m-%d %H:%M:%S'
   prometheus:
     config:
       scrape_configs:
@@ -6,15 +18,36 @@ receivers:
           scrape_interval: 10s
           static_configs:
             - targets: ['127.0.0.1:8888']
-        - job_name: 'otel-collector-metrics'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['127.0.0.1:8889']
 
 processors:
   batch:
     timeout: 1s
     send_batch_size: 1024
+  
+  # Add resource attributes to identify the source
+  resource:
+    attributes:
+      - key: service.name
+        value: "otel-collector-example"
+        action: insert
+      - key: service.version
+        value: "1.0.0"
+        action: insert
+      - key: deployment.environment
+        value: "testing"
+        action: insert
+
+  # Transform logs to add severity and structured data
+  transform/logs:
+    log_statements:
+      - context: log
+        statements:
+          - set(log.severity_text, "INFO") where log.severity_text == nil
+          - set(log.severity_number, 9) where log.severity_number == nil
+          - set(log.attributes["log.source"], "otel-collector-example")
+          # Add event names for proper schema identification
+          - set(log.event_name, log.attributes["service"]) where log.event_name == nil and log.attributes["service"] != nil
+          - set(log.event_name, "application_log") where log.event_name == nil
 
 exporters:
   otlp:
@@ -27,5 +60,10 @@ service:
   pipelines:
     metrics:
       receivers: [prometheus]
-      processors: [batch]
+      processors: [resource, batch]
+      exporters: [otlp]
+    
+    logs:
+      receivers: [filelog]
+      processors: [resource, transform/logs, batch]
       exporters: [otlp] 

--- a/examples/otel-collector-config.yaml
+++ b/examples/otel-collector-config.yaml
@@ -28,13 +28,13 @@ processors:
   resource:
     attributes:
       - key: service.name
-        value: "otel-collector-example"
+        value: "otelcontribcol"
         action: insert
       - key: service.version
-        value: "1.0.0"
+        value: "0.134.0-dev"
         action: insert
       - key: deployment.environment
-        value: "testing"
+        value: "development"
         action: insert
 
   # Transform logs to add severity and structured data
@@ -44,7 +44,7 @@ processors:
         statements:
           - set(log.severity_text, "INFO") where log.severity_text == nil
           - set(log.severity_number, 9) where log.severity_number == nil
-          - set(log.attributes["log.source"], "otel-collector-example")
+          - set(log.attributes["log.source"], "otelcontribcol")
           # Add event names for proper schema identification
           - set(log.event_name, log.attributes["service"]) where log.event_name == nil and log.attributes["service"] != nil
           - set(log.event_name, "application_log") where log.event_name == nil

--- a/internal/grpcserver/logs_service.go
+++ b/internal/grpcserver/logs_service.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"log/slog"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 
 	"github.com/tallycat/tallycat/internal/repository"
+	"github.com/tallycat/tallycat/internal/schema"
 )
 
 type LogsServiceServer struct {
@@ -22,13 +25,68 @@ func NewLogsServiceServer(schemaRepo repository.TelemetrySchemaRepository) *Logs
 }
 
 func (s *LogsServiceServer) Export(ctx context.Context, req *logspb.ExportLogsServiceRequest) (*logspb.ExportLogsServiceResponse, error) {
-	for _, resourceLogs := range req.ResourceLogs {
-		for _, scopeLogs := range resourceLogs.ScopeLogs {
-			for _, logRecord := range scopeLogs.LogRecords {
-				if logRecord.Body != nil && logRecord.Body.GetStringValue() == "tallycat.schema.extracted" {
-				}
+    logs := plog.NewLogs()
+	rls := logs.ResourceLogs()
+	rls.EnsureCapacity(len(req.ResourceLogs))
+	
+	for _, rl := range req.ResourceLogs {
+		resourceLog := rls.AppendEmpty()
+		resourceLog.SetSchemaUrl(rl.SchemaUrl)
+
+		// Convert resource attributes
+		if rl.Resource != nil {
+			for _, attr := range rl.Resource.Attributes {
+				resourceLog.Resource().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
 			}
 		}
+
+		// Convert scope logs
+		sls := resourceLog.ScopeLogs()
+		sls.EnsureCapacity(len(rl.ScopeLogs))
+
+		for _, sl := range rl.ScopeLogs {
+			scopeLog := sls.AppendEmpty()
+			scopeLog.SetSchemaUrl(sl.SchemaUrl)
+
+			// Convert scope
+			if sl.Scope != nil {
+				scopeLog.Scope().SetName(sl.Scope.Name)
+				scopeLog.Scope().SetVersion(sl.Scope.Version)
+				for _, attr := range sl.Scope.Attributes {
+					scopeLog.Scope().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+				}
+			}
+
+			// Convert logs
+			ls := scopeLog.LogRecords()
+			ls.EnsureCapacity(len(sl.LogRecords))
+
+			for _, l := range sl.LogRecords {
+				logRecord := ls.AppendEmpty()
+				logRecord.SetTimestamp(pcommon.Timestamp(l.TimeUnixNano))
+				logRecord.SetObservedTimestamp(pcommon.Timestamp(l.ObservedTimeUnixNano))
+				logRecord.SetSeverityNumber(plog.SeverityNumber(l.SeverityNumber))
+				logRecord.SetSeverityText(l.SeverityText)
+				logRecord.Body().SetStr(l.Body.GetStringValue())
+				logRecord.SetFlags(plog.LogRecordFlags(l.Flags))
+				logRecord.SetTraceID(pcommon.TraceID(l.TraceId))
+				logRecord.SetSpanID(pcommon.SpanID(l.SpanId))
+				logRecord.SetEventName(l.EventName)
+				
+				for _, attr := range l.Attributes {
+					logRecord.Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+				}
+				logRecord.SetDroppedAttributesCount(l.DroppedAttributesCount)
+			}
+		}
+	}
+
+	// Extract schemas from the converted logs
+	schemas := schema.ExtractFromLogs(logs)
+
+	if err := s.schemaRepo.RegisterTelemetrySchemas(ctx, schemas); err != nil {
+		slog.Error("failed to register schemas", "error", err)
+		return nil, err
 	}
 
 	return &logspb.ExportLogsServiceResponse{}, nil

--- a/internal/grpcserver/logs_service.go
+++ b/internal/grpcserver/logs_service.go
@@ -25,10 +25,10 @@ func NewLogsServiceServer(schemaRepo repository.TelemetrySchemaRepository) *Logs
 }
 
 func (s *LogsServiceServer) Export(ctx context.Context, req *logspb.ExportLogsServiceRequest) (*logspb.ExportLogsServiceResponse, error) {
-    logs := plog.NewLogs()
+	logs := plog.NewLogs()
 	rls := logs.ResourceLogs()
 	rls.EnsureCapacity(len(req.ResourceLogs))
-	
+
 	for _, rl := range req.ResourceLogs {
 		resourceLog := rls.AppendEmpty()
 		resourceLog.SetSchemaUrl(rl.SchemaUrl)
@@ -69,10 +69,14 @@ func (s *LogsServiceServer) Export(ctx context.Context, req *logspb.ExportLogsSe
 				logRecord.SetSeverityText(l.SeverityText)
 				logRecord.Body().SetStr(l.Body.GetStringValue())
 				logRecord.SetFlags(plog.LogRecordFlags(l.Flags))
-				logRecord.SetTraceID(pcommon.TraceID(l.TraceId))
-				logRecord.SetSpanID(pcommon.SpanID(l.SpanId))
+				if len(l.TraceId) == 16 {
+					logRecord.SetTraceID(pcommon.TraceID(l.TraceId))
+				}
+				if len(l.SpanId) == 8 {
+					logRecord.SetSpanID(pcommon.SpanID(l.SpanId))
+				}
 				logRecord.SetEventName(l.EventName)
-				
+
 				for _, attr := range l.Attributes {
 					logRecord.Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
 				}

--- a/internal/grpcserver/logs_service_test.go
+++ b/internal/grpcserver/logs_service_test.go
@@ -1,0 +1,66 @@
+package grpcserver_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tallycat/tallycat/internal/integration/testutil"
+)
+
+func TestExportLogs(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataFile string
+		wantErr  bool
+	}{
+		{
+			name:     "single log single schema",
+			dataFile: "single_logrecord_single_schema.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "single log multiple schemas",
+			dataFile: "single_logrecord_multiple_schemas.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "two logs two schemas",
+			dataFile: "two_logrecords_two_schemas.yaml",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		// Setup test database
+		db := testutil.NewTestDB(t)
+		defer db.Close()
+
+		ctx := context.Background()
+		db.SetupTestDB(t)
+		// defer db.CleanupTestDB(t)
+
+		// Setup test server
+		server := testutil.NewTestServer(t, db)
+		defer server.Close()
+
+		// Load test data
+		logs, err := golden.ReadLogs(filepath.Join("testdata", tt.dataFile))
+		require.NoError(t, err)
+
+		// Convert metrics to request
+		req := testutil.ConvertPlogToRequest(logs)
+
+		// Send request to server
+		resp, err := server.LogsClient.Export(ctx, req)
+		if tt.wantErr {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	}
+}

--- a/internal/grpcserver/testdata/single_logrecord_multiple_schemas.yaml
+++ b/internal/grpcserver/testdata/single_logrecord_multiple_schemas.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeLogs:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        logRecords:
+          - timeUnixNano: 1234567890
+            observedTimeUnixNano: 1234567890
+            serverityNumber: 1
+            serverityText: "INFO"
+            body:
+              stringValue: "test"
+            flags: 1
+            traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            eventName: "Reading CPU usage"
+            attributes:
+              - key: cpu
+                value:
+                  stringValue: "0"
+              - key: mode
+                value:
+                  stringValue: "user"
+              - key: state
+                value:
+                  stringValue: "idle"
+              - key: arch
+                value:
+                  stringValue: "x86_64"
+          
+          - timeUnixNano: 1234567890
+            observedTimeUnixNano: 1234567890
+            serverityNumber: 1
+            serverityText: "INFO"
+            body:
+              stringValue: "test"
+            flags: 1
+            traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            eventName: "Reading CPU usage"
+            attributes:
+              - key: cpu
+                value:
+                  stringValue: "1"
+              - key: mode
+                value:
+                  stringValue: "user"
+              - key: state
+                value:
+                  stringValue: "idle"
+              - key: arch
+                value:
+                  stringValue: "x86_64"
+          

--- a/internal/grpcserver/testdata/single_logrecord_single_schema.yaml
+++ b/internal/grpcserver/testdata/single_logrecord_single_schema.yaml
@@ -1,0 +1,47 @@
+resourceLogs:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeLogs:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        logRecords:
+          - timeUnixNano: 1234567890
+            observedTimeUnixNano: 1234567890
+            serverityNumber: 1
+            serverityText: "INFO"
+            body:
+              stringValue: "test"
+            flags: 1
+            traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            eventName: "Reading CPU usage"
+            attributes:
+              - key: cpu
+                value:
+                  stringValue: "1"
+              - key: mode
+                value:
+                  stringValue: "user"
+              - key: state
+                value:
+                  stringValue: "idle"
+              - key: arch
+                value:
+                  stringValue: "x86_64"
+          

--- a/internal/grpcserver/testdata/two_logrecords_two_schemas.yaml
+++ b/internal/grpcserver/testdata/two_logrecords_two_schemas.yaml
@@ -1,0 +1,60 @@
+resourceMetrics:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeMetrics:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        metrics:
+          - timeUnixNano: 1234567890
+            observedTimeUnixNano: 1234567890
+            serverityNumber: 1
+            serverityText: "INFO"
+            body:
+              stringValue: "test"
+            flags: 1
+            traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            eventName: "Reading Memory usage"
+            attributes:
+              - key: type
+                value:
+                  stringValue: "RSS"
+          - timeUnixNano: 1234567890
+            observedTimeUnixNano: 1234567890
+            serverityNumber: 1
+            serverityText: "INFO"
+            body:
+              stringValue: "test"
+            flags: 1
+            traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            eventName: "Reading CPU usage"
+            attributes:
+              - key: cpu
+                value:
+                  stringValue: "1"
+              - key: mode
+                value:
+                  stringValue: "user"
+              - key: state
+                value:
+                  stringValue: "idle"
+              - key: arch
+                value:
+                  stringValue: "x86_64"

--- a/internal/httpserver/api/schema_handlers_test.go
+++ b/internal/httpserver/api/schema_handlers_test.go
@@ -68,11 +68,11 @@ func TestHandleProducerWeaverSchemaExport_ProducerNotFound(t *testing.T) {
 
 	handler := HandleProducerWeaverSchemaExport(mockRepo)
 
-	req := httptest.NewRequest("GET", "/api/v1/producers/non-existent-service@1.0.0/weaver-schema.zip", nil)
+	req := httptest.NewRequest("GET", "/api/v1/producers/non-existent-service---1.0.0/weaver-schema.zip", nil)
 
 	// Set up chi context with URL parameters
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("producerNameVersion", "non-existent-service@1.0.0")
+	rctx.URLParams.Add("producerNameVersion", "non-existent-service---1.0.0")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
@@ -90,11 +90,11 @@ func TestHandleProducerWeaverSchemaExport_ProducerWithNoMetrics(t *testing.T) {
 
 	handler := HandleProducerWeaverSchemaExport(mockRepo)
 
-	req := httptest.NewRequest("GET", "/api/v1/producers/empty-service@1.0.0/weaver-schema.zip", nil)
+	req := httptest.NewRequest("GET", "/api/v1/producers/empty-service---1.0.0/weaver-schema.zip", nil)
 
 	// Set up chi context with URL parameters
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("producerNameVersion", "empty-service@1.0.0")
+	rctx.URLParams.Add("producerNameVersion", "empty-service---1.0.0")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
@@ -149,11 +149,11 @@ func TestHandleProducerWeaverSchemaExport_ProducerWithMetrics(t *testing.T) {
 
 	handler := HandleProducerWeaverSchemaExport(mockRepo)
 
-	req := httptest.NewRequest("GET", "/api/v1/producers/my-service@1.0.0/weaver-schema.zip", nil)
+	req := httptest.NewRequest("GET", "/api/v1/producers/my-service---1.0.0/weaver-schema.zip", nil)
 
 	// Set up chi context with URL parameters
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("producerNameVersion", "my-service@1.0.0")
+	rctx.URLParams.Add("producerNameVersion", "my-service---1.0.0")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
@@ -161,7 +161,7 @@ func TestHandleProducerWeaverSchemaExport_ProducerWithMetrics(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, "application/zip", w.Header().Get("Content-Type"))
-	require.Equal(t, "attachment; filename=my-service@1.0.0.zip", w.Header().Get("Content-Disposition"))
+	require.Equal(t, "attachment; filename=my-service---1.0.0.zip", w.Header().Get("Content-Disposition"))
 	require.NotEmpty(t, w.Body.Bytes())
 
 	mockRepo.AssertExpectations(t)
@@ -196,11 +196,11 @@ func TestHandleProducerWeaverSchemaExport_RepositoryError(t *testing.T) {
 
 	handler := HandleProducerWeaverSchemaExport(mockRepo)
 
-	req := httptest.NewRequest("GET", "/api/v1/producers/error-service@1.0.0/weaver-schema.zip", nil)
+	req := httptest.NewRequest("GET", "/api/v1/producers/error-service---1.0.0/weaver-schema.zip", nil)
 
 	// Set up chi context with URL parameters
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("producerNameVersion", "error-service@1.0.0")
+	rctx.URLParams.Add("producerNameVersion", "error-service---1.0.0")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	w := httptest.NewRecorder()
@@ -219,12 +219,12 @@ func TestParseProducerNameVersion(t *testing.T) {
 		expectedVersion string
 		expectError     bool
 	}{
-		{"my-service@1.0.0", "my-service", "1.0.0", false},
-		{"service@2.1.0", "service", "2.1.0", false},
-		{"complex-service-name@1.2.3", "complex-service-name", "1.2.3", false},
+		{"my-service---1.0.0", "my-service", "1.0.0", false},
+		{"service---2.1.0", "service", "2.1.0", false},
+		{"complex-service-name---1.2.3", "complex-service-name", "1.2.3", false},
 		{"invalid", "", "", true},
-		{"@invalid", "", "", true},
-		{"invalid@", "", "", true},
+		{"---invalid", "", "", true},
+		{"invalid---", "invalid", "", false},
 		{"", "", "", true},
 	}
 

--- a/internal/integration/testutil/logs.go
+++ b/internal/integration/testutil/logs.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"go.opentelemetry.io/collector/pdata/plog"
+	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logpb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+// ConvertPmetricToRequest converts pmetric.Metrics to ExportMetricsServiceRequest
+func ConvertPlogToRequest(ld plog.Logs) *logspb.ExportLogsServiceRequest {
+	request := &logspb.ExportLogsServiceRequest{
+		ResourceLogs: make([]*logpb.ResourceLogs, 0, ld.ResourceLogs().Len()),
+	}
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rm := ld.ResourceLogs().At(i)
+		resourceLogs := &logpb.ResourceLogs{
+			Resource: &resourcepb.Resource{
+				Attributes: convertAttributes(rm.Resource().Attributes()),
+			},
+			ScopeLogs: make([]*logpb.ScopeLogs, 0, rm.ScopeLogs().Len()),
+			SchemaUrl: rm.SchemaUrl(),
+		}
+
+		for j := 0; j < rm.ScopeLogs().Len(); j++ {
+			sm := rm.ScopeLogs().At(j)
+			scopeLogs := &logpb.ScopeLogs{
+				Scope: &commonpb.InstrumentationScope{
+					Name:    sm.Scope().Name(),
+					Version: sm.Scope().Version(),
+				},
+				LogRecords: make([]*logpb.LogRecord, 0, sm.LogRecords().Len()),
+				SchemaUrl:  sm.SchemaUrl(),
+			}
+
+			for k := 0; k < sm.LogRecords().Len(); k++ {
+				l := sm.LogRecords().At(k)
+				traceID := l.TraceID()
+				spanID := l.SpanID()
+				logRecord := &logpb.LogRecord{
+					TimeUnixNano:         uint64(l.Timestamp()),
+					ObservedTimeUnixNano: uint64(l.ObservedTimestamp()),
+					SeverityNumber:       logpb.SeverityNumber(l.SeverityNumber()),
+					SeverityText:         l.SeverityText(),
+					Body: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_StringValue{
+							StringValue: l.Body().AsString(),
+						},
+					},
+					Flags:     uint32(l.Flags()),
+					TraceId:   traceID[:],
+					SpanId:    spanID[:],
+					EventName: l.EventName(),
+				}
+				scopeLogs.LogRecords = append(scopeLogs.LogRecords, logRecord)
+			}
+			resourceLogs.ScopeLogs = append(resourceLogs.ScopeLogs, scopeLogs)
+		}
+		request.ResourceLogs = append(request.ResourceLogs, resourceLogs)
+	}
+	return request
+}

--- a/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
+++ b/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
@@ -5,10 +5,21 @@ CREATE TABLE IF NOT EXISTS telemetry_schemas (
     schema_version TEXT,
     schema_url TEXT,
     signal_type TEXT,
+    -- Metric fields
     metric_type TEXT,
     temporality TEXT,
     unit TEXT,
     brief TEXT,
+    -- Log fields
+    log_severity_number INTEGER,
+    log_severity_text TEXT,
+    log_body TEXT,
+    log_flags INTEGER,
+    log_trace_id TEXT,
+    log_span_id TEXT,
+    log_event_name TEXT,
+    log_dropped_attributes_count INTEGER,
+    -- Common fields
     note TEXT,
     protocol TEXT,
     seen_count INTEGER,

--- a/internal/schema/attribute.go
+++ b/internal/schema/attribute.go
@@ -26,7 +26,9 @@ type AttributeSource string
 const (
 	AttributeSourceResource  AttributeSource = "Resource"
 	AttributeSourceScope     AttributeSource = "Scope"
+
 	AttributeSourceDataPoint AttributeSource = "DataPoint"
+	AttributeSourceLogRecord AttributeSource = "LogRecord"
 )
 
 type Attribute struct {

--- a/internal/schema/telemetry.go
+++ b/internal/schema/telemetry.go
@@ -34,24 +34,36 @@ type TelemetryType string
 
 const (
 	TelemetryTypeMetric TelemetryType = "Metric"
+	TelemetryTypeLog    TelemetryType = "Log"
 )
 
 type Telemetry struct {
-	SchemaID          string            `json:"schemaId"`
-	SchemaVersion     string            `json:"schemaVersion"`
-	SchemaURL         string            `json:"schemaURL,omitempty"`
-	SchemaKey         string            `json:"schemaKey"`
-	TelemetryType     TelemetryType     `json:"telemetryType"`
+	SchemaID      string        `json:"schemaId"`
+	SchemaVersion string        `json:"schemaVersion"`
+	SchemaURL     string        `json:"schemaURL,omitempty"`
+	SchemaKey     string        `json:"schemaKey"`
+	TelemetryType TelemetryType `json:"telemetryType"`
+	// Metric fields
 	MetricUnit        string            `json:"metricUnit"`
 	MetricType        MetricType        `json:"metricType"`
 	MetricTemporality MetricTemporality `json:"metricTemporality"`
-	Attributes        []Attribute       `json:"attributes"`
 	Brief             string            `json:"brief,omitempty"`
-	Note              string            `json:"note,omitempty"`
-	Protocol          TelemetryProtocol `json:"protocol"`
-	SeenCount         int               `json:"seenCount"`
-	CreatedAt         time.Time         `json:"createdAt"`
-	UpdatedAt         time.Time         `json:"updatedAt"`
+	//Log fields
+	LogSeverityNumber         int    `json:"logSeverityNumber"`
+	LogSeverityText           string `json:"logSeverityText"`
+	LogBody                   string `json:"logBody"`
+	LogFlags                  int    `json:"logFlags"`
+	LogTraceID                string `json:"logTraceID"`
+	LogSpanID                 string `json:"logSpanID"`
+	LogEventName              string `json:"logEventName"`
+	LogDroppedAttributesCount int    `json:"logDroppedAttributesCount"`
+
+	Attributes []Attribute       `json:"attributes"`
+	Note       string            `json:"note,omitempty"`
+	Protocol   TelemetryProtocol `json:"protocol"`
+	SeenCount  int               `json:"seenCount"`
+	CreatedAt  time.Time         `json:"createdAt"`
+	UpdatedAt  time.Time         `json:"updatedAt"`
 	// Producers maps producer keys to their information
 	Producers map[string]*Producer `json:"producers"`
 }

--- a/ui/src/components/telemetry-catalog/features/schema-definition/AttributesView.tsx
+++ b/ui/src/components/telemetry-catalog/features/schema-definition/AttributesView.tsx
@@ -49,7 +49,7 @@ export function AttributesView({ attributes }: AttributesViewProps) {
     (attr) => attr.source === 'Scope'
   )
   const dataPointAttributes = filteredAttributes.filter(
-    (attr) => attr.source === 'DataPoint'
+    (attr) => attr.source === 'DataPoint' || attr.source === 'LogRecord'
   )
 
   const toggleSection = (section: keyof typeof expandedSections) => {

--- a/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
+++ b/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
@@ -43,7 +43,7 @@ export function TelemetryOverviewPanel({
         <div className="p-5 border-r">
           <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-1.5">
             <BarChart2 className="h-4 w-4 text-green-500" />
-            Metrics & Structure
+            {telemetry.telemetryType} & Structure
           </h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between">

--- a/ui/src/routes/data-governance/telemetry-catalog.tsx
+++ b/ui/src/routes/data-governance/telemetry-catalog.tsx
@@ -425,6 +425,7 @@ export const SchemaCatalog = () => {
             <TabsTrigger value="metric">Metrics</TabsTrigger>
             <TabsTrigger value="log">Logs</TabsTrigger>
             <TabsTrigger value="trace">Traces</TabsTrigger>
+            <TabsTrigger value="profile">Profiles</TabsTrigger>
           </TabsList>
         </Tabs>
 

--- a/ui/src/types/telemetry.ts
+++ b/ui/src/types/telemetry.ts
@@ -2,7 +2,7 @@ export enum TelemetryType {
   Metric = 'Metric',
   Log = 'Log',
   Trace = 'Trace',
-  Event = 'Event',
+  Profile = 'Profile',
 }
 
 export enum Status {

--- a/ui/src/types/telemetry.ts
+++ b/ui/src/types/telemetry.ts
@@ -27,9 +27,20 @@ export interface Telemetry {
   schemaKey: string
   schemaUrl?: string
   telemetryType: TelemetryType
+  // Metric fields
   metricUnit: string
   metricType: string
   metricTemporality: string
+  // Log fields
+  logSeverityNumber: number
+  logSeverityText: string
+  logBody: string
+  logFlags: number
+  logTraceID: string
+  logSpanID: string
+  logEventName: string
+  logDroppedAttributesCount: number
+  // Common fields
   brief?: string
   note?: string
   protocol: string
@@ -44,6 +55,7 @@ export interface Attribute {
   name: string
   type: string
   source: string
+  brief?: string
 }
 
 export interface TelemetryHistory {


### PR DESCRIPTION
Initially opening as a draft, still a bit to do before calling this ready.


- [X] Update `Telemetry` Go struct to support log-related fields.
- [x] Update Database table to support log-related fields.
- [X] Implement `ExtractFromLogs`, which transforms OTLP logs into TallyCat's `Telemetry`.
- [x] Implement insertion of LogRecords into the database.
- [x] Implement API to request WeaverSchema from logs
