### PR TITLE
Ingest trace spans

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tallycat/tallycat/internal/repository/duckdb/migrator"
 	logspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	tracespb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -88,6 +89,9 @@ and processes log data according to the OpenTelemetry protocol.`,
 
 		metricsService := grpcserver.NewMetricsServiceServer(schemaRepo)
 		srv.RegisterService(&metricspb.MetricsService_ServiceDesc, metricsService)
+
+		tracesService := grpcserver.NewTracesServiceServer(schemaRepo)
+		srv.RegisterService(&tracespb.TraceService_ServiceDesc, tracesService)
 
 		httpSrv := httpserver.New(httpAddr, schemaRepo, historyRepo)
 

--- a/examples/otel-collector-config.yaml
+++ b/examples/otel-collector-config.yaml
@@ -1,4 +1,12 @@
 receivers:
+  # OTLP receiver for traces, metrics, and logs
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4318
+      http:
+        endpoint: 0.0.0.0:4319
+
   # Generate synthetic logs for testing
   filelog:
     include: ["examples/test-logs/*.log"]
@@ -11,6 +19,7 @@ receivers:
         id: extract_timestamp_parser
         parse_from: attributes.timestamp
         layout: '%Y-%m-%d %H:%M:%S'
+  
   prometheus:
     config:
       scrape_configs:
@@ -49,6 +58,18 @@ processors:
           - set(log.event_name, log.attributes["service"]) where log.event_name == nil and log.attributes["service"] != nil
           - set(log.event_name, "application_log") where log.event_name == nil
 
+  # Transform traces to add additional attributes for testing
+  transform/traces:
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["trace.source"], "otelcontribcol")
+          - set(attributes["environment"], "development")
+          # Add some test attributes based on span name
+          - set(attributes["operation.category"], "database") where name == "SELECT users"
+          - set(attributes["operation.category"], "http") where name == "GET /api/users"
+          - set(attributes["operation.category"], "cache") where name == "redis.get"
+
 exporters:
   otlp:
     endpoint: localhost:4317
@@ -58,6 +79,11 @@ exporters:
 
 service:
   pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource, transform/traces, batch]
+      exporters: [otlp]
+    
     metrics:
       receivers: [prometheus]
       processors: [resource, batch]

--- a/internal/grpcserver/testdata/single_trace_multiple_schemas.yaml
+++ b/internal/grpcserver/testdata/single_trace_multiple_schemas.yaml
@@ -1,0 +1,83 @@
+resourceSpans:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeSpans:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        spans:
+          - traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            parentSpanId: ""
+            name: "test-operation"
+            kind: 1
+            startTimeUnixNano: 1234567890000000000
+            endTimeUnixNano: 1234567891000000000
+            attributes:
+              - key: operation.type
+                value:
+                  stringValue: "database"
+              - key: db.system
+                value:
+                  stringValue: "postgresql"
+              - key: db.name
+                value:
+                  stringValue: "testdb"
+            droppedAttributesCount: 0
+            events:
+              - timeUnixNano: 1234567890500000000
+                name: "query.start"
+                attributes:
+                  - key: query
+                    value:
+                      stringValue: "SELECT * FROM users"
+                droppedAttributesCount: 0
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              code: 1
+              message: ""
+          - traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "ABCDEF1234567890"
+            parentSpanId: "1234567890ABCDEF"
+            name: "http-request"
+            kind: 3
+            startTimeUnixNano: 1234567890000000000
+            endTimeUnixNano: 1234567891000000000
+            attributes:
+              - key: http.method
+                value:
+                  stringValue: "GET"
+              - key: http.url
+                value:
+                  stringValue: "https://api.example.com/users"
+              - key: http.status_code
+                value:
+                  intValue: 200
+              - key: user.region
+                value:
+                  stringValue: "us-west-2"
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              code: 1
+              message: ""

--- a/internal/grpcserver/testdata/single_trace_single_schema.yaml
+++ b/internal/grpcserver/testdata/single_trace_single_schema.yaml
@@ -1,0 +1,55 @@
+resourceSpans:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeSpans:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        spans:
+          - traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            parentSpanId: ""
+            name: "test-operation"
+            kind: 1
+            startTimeUnixNano: 1234567890000000000
+            endTimeUnixNano: 1234567891000000000
+            attributes:
+              - key: operation.type
+                value:
+                  stringValue: "database"
+              - key: db.system
+                value:
+                  stringValue: "postgresql"
+              - key: db.name
+                value:
+                  stringValue: "testdb"
+            droppedAttributesCount: 0
+            events:
+              - timeUnixNano: 1234567890500000000
+                name: "query.start"
+                attributes:
+                  - key: query
+                    value:
+                      stringValue: "SELECT * FROM users"
+                droppedAttributesCount: 0
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              code: 1
+              message: ""

--- a/internal/grpcserver/testdata/two_traces_two_schemas.yaml
+++ b/internal/grpcserver/testdata/two_traces_two_schemas.yaml
@@ -1,0 +1,102 @@
+resourceSpans:
+  - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: test-service
+        - key: service.version
+          value:
+            stringValue: "1.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "production"
+    scopeSpans:
+      - schemaUrl: https://opentelemetry.io/schemas/1.9.0
+        scope:
+          name: test-instrumentation
+          version: "1.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "test"
+        spans:
+          - traceId: "1234567890ABCDEF1234567890ABCDEF"
+            spanId: "1234567890ABCDEF"
+            parentSpanId: ""
+            name: "database-operation"
+            kind: 1
+            startTimeUnixNano: 1234567890000000000
+            endTimeUnixNano: 1234567891000000000
+            attributes:
+              - key: operation.type
+                value:
+                  stringValue: "database"
+              - key: db.system
+                value:
+                  stringValue: "postgresql"
+            droppedAttributesCount: 0
+            events: []
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              code: 1
+              message: ""
+  - schemaUrl: https://opentelemetry.io/schemas/1.10.0
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: api-service
+        - key: service.version
+          value:
+            stringValue: "2.0.0"
+        - key: deployment.environment.name
+          value:
+            stringValue: "staging"
+    scopeSpans:
+      - schemaUrl: https://opentelemetry.io/schemas/1.10.0
+        scope:
+          name: api-instrumentation
+          version: "2.0.0"
+          attributes:
+            - key: instrumentation.provider
+              value:
+                stringValue: "opentelemetry"
+        spans:
+          - traceId: "ABCDEF1234567890ABCDEF1234567890"
+            spanId: "ABCDEF1234567890"
+            parentSpanId: ""
+            name: "http-request"
+            kind: 3
+            startTimeUnixNano: 1234567892000000000
+            endTimeUnixNano: 1234567893000000000
+            attributes:
+              - key: http.method
+                value:
+                  stringValue: "POST"
+              - key: http.url
+                value:
+                  stringValue: "https://api.example.com/orders"
+              - key: http.status_code
+                value:
+                  intValue: 201
+              - key: user.region
+                value:
+                  stringValue: "eu-west-1"
+            droppedAttributesCount: 0
+            events:
+              - timeUnixNano: 1234567892500000000
+                name: "request.validated"
+                attributes:
+                  - key: validation.result
+                    value:
+                      stringValue: "success"
+                droppedAttributesCount: 0
+            droppedEventsCount: 0
+            links: []
+            droppedLinksCount: 0
+            status:
+              code: 1
+              message: ""

--- a/internal/grpcserver/traces_service.go
+++ b/internal/grpcserver/traces_service.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	tracespb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 
 	"github.com/tallycat/tallycat/internal/repository"
 	"github.com/tallycat/tallycat/internal/schema"
@@ -24,6 +25,36 @@ func NewTracesServiceServer(schemaRepo repository.TelemetrySchemaRepository) *Tr
 	}
 }
 
+// convertAttributeValue converts a protobuf AnyValue to the appropriate pcommon value
+func convertAttributeValue(attrs pcommon.Map, key string, value *commonpb.AnyValue) {
+	if value == nil {
+		return
+	}
+
+	switch v := value.Value.(type) {
+	case *commonpb.AnyValue_StringValue:
+		attrs.PutStr(key, v.StringValue)
+	case *commonpb.AnyValue_BoolValue:
+		attrs.PutBool(key, v.BoolValue)
+	case *commonpb.AnyValue_IntValue:
+		attrs.PutInt(key, v.IntValue)
+	case *commonpb.AnyValue_DoubleValue:
+		attrs.PutDouble(key, v.DoubleValue)
+	case *commonpb.AnyValue_ArrayValue:
+		// For arrays, convert to string representation
+		attrs.PutStr(key, value.String())
+	case *commonpb.AnyValue_KvlistValue:
+		// For key-value lists, convert to string representation
+		attrs.PutStr(key, value.String())
+	case *commonpb.AnyValue_BytesValue:
+		// For bytes, convert to string
+		attrs.PutStr(key, string(v.BytesValue))
+	default:
+		// Fallback to string representation
+		attrs.PutStr(key, value.String())
+	}
+}
+
 func (s *TracesServiceServer) Export(ctx context.Context, req *tracespb.ExportTraceServiceRequest) (*tracespb.ExportTraceServiceResponse, error) {
 	traces := ptrace.NewTraces()
 	rts := traces.ResourceSpans()
@@ -36,7 +67,7 @@ func (s *TracesServiceServer) Export(ctx context.Context, req *tracespb.ExportTr
 		// Convert resource attributes
 		if rt.Resource != nil {
 			for _, attr := range rt.Resource.Attributes {
-				resourceSpan.Resource().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+				convertAttributeValue(resourceSpan.Resource().Attributes(), attr.Key, attr.Value)
 			}
 		}
 
@@ -53,7 +84,7 @@ func (s *TracesServiceServer) Export(ctx context.Context, req *tracespb.ExportTr
 				scopeSpan.Scope().SetName(st.Scope.Name)
 				scopeSpan.Scope().SetVersion(st.Scope.Version)
 				for _, attr := range st.Scope.Attributes {
-					scopeSpan.Scope().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+					convertAttributeValue(scopeSpan.Scope().Attributes(), attr.Key, attr.Value)
 				}
 			}
 
@@ -65,35 +96,66 @@ func (s *TracesServiceServer) Export(ctx context.Context, req *tracespb.ExportTr
 				span := ls.AppendEmpty()
 				span.SetKind(ptrace.SpanKind(s.Kind))
 				span.SetName(s.Name)
-				span.SetParentSpanID(pcommon.SpanID(s.ParentSpanId))
-				span.SetSpanID(pcommon.SpanID(s.SpanId))
-				span.SetTraceID(pcommon.TraceID(s.TraceId))
+
+				// Safely convert ParentSpanID (8 bytes expected)
+				if len(s.ParentSpanId) == 8 {
+					span.SetParentSpanID(pcommon.SpanID(s.ParentSpanId))
+				}
+
+				// Safely convert SpanID (8 bytes expected)
+				if len(s.SpanId) == 8 {
+					span.SetSpanID(pcommon.SpanID(s.SpanId))
+				}
+
+				// Safely convert TraceID (16 bytes expected)
+				if len(s.TraceId) == 16 {
+					span.SetTraceID(pcommon.TraceID(s.TraceId))
+				}
 				span.SetStartTimestamp(pcommon.Timestamp(s.StartTimeUnixNano))
 				span.SetEndTimestamp(pcommon.Timestamp(s.EndTimeUnixNano))
 				span.SetFlags(uint32(s.Flags))
 				span.Status().SetCode(ptrace.StatusCode(s.Status.Code))
 				span.Status().SetMessage(s.Status.Message)
-				
+
 				for _, attr := range s.Attributes {
-					span.Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+					convertAttributeValue(span.Attributes(), attr.Key, attr.Value)
 				}
 				span.SetDroppedAttributesCount(s.DroppedAttributesCount)
 				span.SetDroppedLinksCount(s.DroppedLinksCount)
-				
+
 				for _, event := range s.Events {
 					spanEvent := span.Events().AppendEmpty()
 					spanEvent.SetName(event.Name)
 					spanEvent.SetTimestamp(pcommon.Timestamp(event.TimeUnixNano))
 					spanEvent.SetDroppedAttributesCount(event.DroppedAttributesCount)
+
+					// Convert event attributes
+					for _, attr := range event.Attributes {
+						convertAttributeValue(spanEvent.Attributes(), attr.Key, attr.Value)
+					}
 				}
 				span.SetDroppedEventsCount(s.DroppedEventsCount)
 
 				for _, link := range s.Links {
 					spanLink := span.Links().AppendEmpty()
-					spanLink.SetTraceID(pcommon.TraceID(link.TraceId))
-					spanLink.SetSpanID(pcommon.SpanID(link.SpanId))
+
+					// Safely convert TraceID (16 bytes expected)
+					if len(link.TraceId) == 16 {
+						spanLink.SetTraceID(pcommon.TraceID(link.TraceId))
+					}
+
+					// Safely convert SpanID (8 bytes expected)
+					if len(link.SpanId) == 8 {
+						spanLink.SetSpanID(pcommon.SpanID(link.SpanId))
+					}
+
 					spanLink.SetDroppedAttributesCount(link.DroppedAttributesCount)
 					spanLink.SetFlags(uint32(link.Flags))
+
+					// Convert link attributes
+					for _, attr := range link.Attributes {
+						convertAttributeValue(spanLink.Attributes(), attr.Key, attr.Value)
+					}
 				}
 				span.SetDroppedLinksCount(s.DroppedLinksCount)
 			}

--- a/internal/grpcserver/traces_service.go
+++ b/internal/grpcserver/traces_service.go
@@ -1,0 +1,112 @@
+package grpcserver
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	tracespb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+
+	"github.com/tallycat/tallycat/internal/repository"
+	"github.com/tallycat/tallycat/internal/schema"
+)
+
+type TracesServiceServer struct {
+	tracespb.UnimplementedTraceServiceServer
+	schemaRepo repository.TelemetrySchemaRepository
+	logger     *slog.Logger
+}
+
+func NewTracesServiceServer(schemaRepo repository.TelemetrySchemaRepository) *TracesServiceServer {
+	return &TracesServiceServer{
+		schemaRepo: schemaRepo,
+	}
+}
+
+func (s *TracesServiceServer) Export(ctx context.Context, req *tracespb.ExportTraceServiceRequest) (*tracespb.ExportTraceServiceResponse, error) {
+	traces := ptrace.NewTraces()
+	rts := traces.ResourceSpans()
+	rts.EnsureCapacity(len(req.ResourceSpans))
+
+	for _, rt := range req.ResourceSpans {
+		resourceSpan := rts.AppendEmpty()
+		resourceSpan.SetSchemaUrl(rt.SchemaUrl)
+
+		// Convert resource attributes
+		if rt.Resource != nil {
+			for _, attr := range rt.Resource.Attributes {
+				resourceSpan.Resource().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+			}
+		}
+
+		// Convert scope spans
+		sts := resourceSpan.ScopeSpans()
+		sts.EnsureCapacity(len(rt.ScopeSpans))
+
+		for _, st := range rt.ScopeSpans {
+			scopeSpan := sts.AppendEmpty()
+			scopeSpan.SetSchemaUrl(st.SchemaUrl)
+
+			// Convert scope
+			if st.Scope != nil {
+				scopeSpan.Scope().SetName(st.Scope.Name)
+				scopeSpan.Scope().SetVersion(st.Scope.Version)
+				for _, attr := range st.Scope.Attributes {
+					scopeSpan.Scope().Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+				}
+			}
+
+			// Convert logs
+			ls := scopeSpan.Spans()
+			ls.EnsureCapacity(len(st.Spans))
+
+			for _, s := range st.Spans {
+				span := ls.AppendEmpty()
+				span.SetKind(ptrace.SpanKind(s.Kind))
+				span.SetName(s.Name)
+				span.SetParentSpanID(pcommon.SpanID(s.ParentSpanId))
+				span.SetSpanID(pcommon.SpanID(s.SpanId))
+				span.SetTraceID(pcommon.TraceID(s.TraceId))
+				span.SetStartTimestamp(pcommon.Timestamp(s.StartTimeUnixNano))
+				span.SetEndTimestamp(pcommon.Timestamp(s.EndTimeUnixNano))
+				span.SetFlags(uint32(s.Flags))
+				span.Status().SetCode(ptrace.StatusCode(s.Status.Code))
+				span.Status().SetMessage(s.Status.Message)
+				
+				for _, attr := range s.Attributes {
+					span.Attributes().PutStr(attr.Key, attr.Value.GetStringValue())
+				}
+				span.SetDroppedAttributesCount(s.DroppedAttributesCount)
+				span.SetDroppedLinksCount(s.DroppedLinksCount)
+				
+				for _, event := range s.Events {
+					spanEvent := span.Events().AppendEmpty()
+					spanEvent.SetName(event.Name)
+					spanEvent.SetTimestamp(pcommon.Timestamp(event.TimeUnixNano))
+					spanEvent.SetDroppedAttributesCount(event.DroppedAttributesCount)
+				}
+				span.SetDroppedEventsCount(s.DroppedEventsCount)
+
+				for _, link := range s.Links {
+					spanLink := span.Links().AppendEmpty()
+					spanLink.SetTraceID(pcommon.TraceID(link.TraceId))
+					spanLink.SetSpanID(pcommon.SpanID(link.SpanId))
+					spanLink.SetDroppedAttributesCount(link.DroppedAttributesCount)
+					spanLink.SetFlags(uint32(link.Flags))
+				}
+				span.SetDroppedLinksCount(s.DroppedLinksCount)
+			}
+		}
+	}
+
+	// Extract schemas from the converted traces
+	schemas := schema.ExtractFromTraces(traces)
+
+	if err := s.schemaRepo.RegisterTelemetrySchemas(ctx, schemas); err != nil {
+		slog.Error("failed to register schemas", "error", err)
+		return nil, err
+	}
+
+	return &tracespb.ExportTraceServiceResponse{}, nil
+}

--- a/internal/grpcserver/traces_service_test.go
+++ b/internal/grpcserver/traces_service_test.go
@@ -1,0 +1,66 @@
+package grpcserver_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tallycat/tallycat/internal/integration/testutil"
+)
+
+func TestExportTraces(t *testing.T) {
+	tests := []struct {
+		name     string
+		dataFile string
+		wantErr  bool
+	}{
+		{
+			name:     "single trace single schema",
+			dataFile: "single_trace_single_schema.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "single trace multiple schemas",
+			dataFile: "single_trace_multiple_schemas.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "two traces two schemas",
+			dataFile: "two_traces_two_schemas.yaml",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		// Setup test database
+		db := testutil.NewTestDB(t)
+		defer db.Close()
+
+		ctx := context.Background()
+		db.SetupTestDB(t)
+		// defer db.CleanupTestDB(t)
+
+		// Setup test server
+		server := testutil.NewTestServer(t, db)
+		defer server.Close()
+
+		// Load test data
+		traces, err := golden.ReadTraces(filepath.Join("testdata", tt.dataFile))
+		require.NoError(t, err)
+
+		// Convert traces to request
+		req := testutil.ConvertPtraceToRequest(traces)
+
+		// Send request to server
+		resp, err := server.TracesClient.Export(ctx, req)
+		if tt.wantErr {
+			require.Error(t, err)
+			return
+		}
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	}
+}

--- a/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
+++ b/internal/repository/duckdb/migrations/000001_create_schema_tables.up.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS telemetry_schemas (
     log_span_id TEXT,
     log_event_name TEXT,
     log_dropped_attributes_count INTEGER,
+    -- Span fields
+    span_kind TEXT,
+    span_name TEXT,
+    span_id TEXT,
+    span_trace_id TEXT,
     -- Common fields
     note TEXT,
     protocol TEXT,

--- a/internal/repository/duckdb/telemetry_schema.go
+++ b/internal/repository/duckdb/telemetry_schema.go
@@ -35,8 +35,9 @@ func (r *TelemetrySchemaRepository) RegisterTelemetrySchemas(ctx context.Context
 			schema_id, schema_key, schema_version, schema_url, signal_type, 
 			metric_type, temporality, unit, brief, 
 			log_severity_number, log_severity_text, log_body, log_flags, log_trace_id, log_span_id, log_event_name, log_dropped_attributes_count,
+			span_kind, span_name, span_id, span_trace_id,
 			note, protocol, seen_count, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (schema_id) DO UPDATE SET
 			seen_count = telemetry_schemas.seen_count + excluded.seen_count,
 			updated_at = excluded.updated_at
@@ -90,6 +91,10 @@ func (r *TelemetrySchemaRepository) RegisterTelemetrySchemas(ctx context.Context
 			schema.LogSpanID,
 			schema.LogEventName,
 			schema.LogDroppedAttributesCount,
+			schema.SpanKind,
+			schema.SpanName,
+			schema.SpanID,
+			schema.SpanTraceID,
 			schema.Note,
 			schema.Protocol,
 			schema.SeenCount,
@@ -206,6 +211,11 @@ func (r *TelemetrySchemaRepository) ListTelemetries(ctx context.Context, params 
 				t.log_span_id,
 				t.log_event_name,
 				t.log_dropped_attributes_count,
+				-- Span fields
+				t.span_kind,
+				t.span_name,
+				t.span_id,
+				t.span_trace_id,
 				-- Common fields
 				t.note,
 				t.protocol,
@@ -224,6 +234,7 @@ func (r *TelemetrySchemaRepository) ListTelemetries(ctx context.Context, params 
 			schema_id, schema_version, schema_url, signal_type, schema_key, 
 			unit, metric_type, temporality, brief,
 			log_severity_number, log_severity_text, log_body, log_flags, log_trace_id, log_span_id, log_event_name, log_dropped_attributes_count,
+			span_kind, span_name, span_id, span_trace_id,
 			note, protocol, seen_count,
 			created_at, updated_at, version_count
 		FROM latest_schemas
@@ -268,6 +279,10 @@ func (r *TelemetrySchemaRepository) ListTelemetries(ctx context.Context, params 
 			&schema.LogSpanID,
 			&schema.LogEventName,
 			&schema.LogDroppedAttributesCount,
+			&schema.SpanKind,
+			&schema.SpanName,
+			&schema.SpanID,
+			&schema.SpanTraceID,
 			&schema.Note,
 			&schema.Protocol,
 			&schema.SeenCount,
@@ -310,6 +325,11 @@ func (r *TelemetrySchemaRepository) GetTelemetry(ctx context.Context, schemaKey 
 						t.log_span_id,
 						t.log_event_name,
 						t.log_dropped_attributes_count,
+						-- Span fields
+						t.span_kind,
+						t.span_name,
+						t.span_id,
+						t.span_trace_id,
 						-- Common fields
 						t.note,
 						t.protocol,
@@ -344,6 +364,11 @@ func (r *TelemetrySchemaRepository) GetTelemetry(ctx context.Context, schemaKey 
 			log_span_id,
 			log_event_name,
 			log_dropped_attributes_count,
+			-- Span fields
+			span_kind,
+			span_name,
+			span_id,
+			span_trace_id,
 			-- Common fields
 			note,
 			protocol,
@@ -381,6 +406,10 @@ func (r *TelemetrySchemaRepository) GetTelemetry(ctx context.Context, schemaKey 
 		&s.LogSpanID,
 		&s.LogEventName,
 		&s.LogDroppedAttributesCount,
+		&s.SpanKind,
+		&s.SpanName,
+		&s.SpanID,
+		&s.SpanTraceID,
 		&s.Note,
 		&s.Protocol,
 		&s.SeenCount,
@@ -724,6 +753,11 @@ func (r *TelemetrySchemaRepository) ListTelemetriesByProducer(ctx context.Contex
 					t.log_span_id,
 					t.log_event_name,
 					t.log_dropped_attributes_count,
+					-- Span fields
+					t.span_kind,
+					t.span_name,
+					t.span_id,
+					t.span_trace_id,
 					-- Common fields
 					t.note,
 					t.protocol,
@@ -742,6 +776,7 @@ func (r *TelemetrySchemaRepository) ListTelemetriesByProducer(ctx context.Contex
 				schema_id, schema_version, schema_url, signal_type, schema_key,
 				unit, metric_type, temporality, brief,
 				log_severity_number, log_severity_text, log_body, log_flags, log_trace_id, log_span_id, log_event_name, log_dropped_attributes_count,
+				span_kind, span_name, span_id, span_trace_id,
 				note, protocol, seen_count,
 				created_at, updated_at
 			FROM latest_schemas
@@ -771,6 +806,11 @@ func (r *TelemetrySchemaRepository) ListTelemetriesByProducer(ctx context.Contex
 					t.log_span_id,
 					t.log_event_name,
 					t.log_dropped_attributes_count,
+					-- Span fields
+					t.span_kind,
+					t.span_name,
+					t.span_id,
+					t.span_trace_id,
 					-- Common fields
 					t.note,
 					t.protocol,
@@ -789,6 +829,7 @@ func (r *TelemetrySchemaRepository) ListTelemetriesByProducer(ctx context.Contex
 				schema_id, schema_version, schema_url, signal_type, schema_key,
 				unit, metric_type, temporality, brief,
 				log_severity_number, log_severity_text, log_body, log_flags, log_trace_id, log_span_id, log_event_name, log_dropped_attributes_count,
+				span_kind, span_name, span_id, span_trace_id,
 				note, protocol, seen_count,
 				created_at, updated_at
 			FROM latest_schemas
@@ -831,6 +872,10 @@ func (r *TelemetrySchemaRepository) ListTelemetriesByProducer(ctx context.Contex
 			&t.LogSpanID,
 			&t.LogEventName,
 			&t.LogDroppedAttributesCount,
+			&t.SpanKind,
+			&t.SpanName,
+			&t.SpanID,
+			&t.SpanTraceID,
 			&t.Note,
 			&t.Protocol,
 			&t.SeenCount,

--- a/internal/repository/duckdb/telemetry_schema_test.go
+++ b/internal/repository/duckdb/telemetry_schema_test.go
@@ -491,7 +491,7 @@ func TestListTelemetriesByProducer_ProducerWithTraces(t *testing.T) {
 		{
 			SchemaID:      "trace1_schema_id",
 			SchemaKey:     "database-operation",
-			TelemetryType: schema.TelemetryTypeTrace,
+			TelemetryType: schema.TelemetryTypeSpan,
 			// Metric fields
 			MetricType: schema.MetricTypeEmpty,
 			MetricUnit: "",
@@ -528,7 +528,7 @@ func TestListTelemetriesByProducer_ProducerWithTraces(t *testing.T) {
 		{
 			SchemaID:      "trace2_schema_id",
 			SchemaKey:     "http-request",
-			TelemetryType: schema.TelemetryTypeTrace,
+			TelemetryType: schema.TelemetryTypeSpan,
 			// Metric fields
 			MetricType: schema.MetricTypeEmpty,
 			MetricUnit: "",
@@ -565,7 +565,7 @@ func TestListTelemetriesByProducer_ProducerWithTraces(t *testing.T) {
 		{
 			SchemaID:      "trace3_schema_id",
 			SchemaKey:     "Random operation",
-			TelemetryType: schema.TelemetryTypeTrace,
+			TelemetryType: schema.TelemetryTypeSpan,
 			// Metric fields
 			MetricType: schema.MetricTypeEmpty,
 			MetricUnit: "",
@@ -630,7 +630,7 @@ func TestListTelemetriesByProducer_ProducerWithNoTraces(t *testing.T) {
 		{
 			SchemaID:      "trace1_schema_id",
 			SchemaKey:     "database-operation",
-			TelemetryType: schema.TelemetryTypeTrace,
+			TelemetryType: schema.TelemetryTypeSpan,
 			// Metric fields
 			MetricType: schema.MetricTypeEmpty,
 			MetricUnit: "",

--- a/internal/repository/duckdb/telemetry_schema_test.go
+++ b/internal/repository/duckdb/telemetry_schema_test.go
@@ -46,6 +46,11 @@ func setupTestDB(t *testing.T) *TelemetrySchemaRepository {
 			log_span_id TEXT,
 			log_event_name TEXT,
 			log_dropped_attributes_count INTEGER,
+			-- Span fields
+			span_kind TEXT,
+			span_name TEXT,
+			span_id TEXT,
+			span_trace_id TEXT,
 			-- Common fields
 			note TEXT,
 			protocol TEXT,
@@ -114,6 +119,11 @@ func TestListTelemetriesByProducer_ProducerWithMetrics(t *testing.T) {
 			LogSpanID:                 "",
 			LogEventName:              "",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 10,
@@ -145,6 +155,11 @@ func TestListTelemetriesByProducer_ProducerWithMetrics(t *testing.T) {
 			LogSpanID:                 "",
 			LogEventName:              "",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 5,
@@ -176,6 +191,11 @@ func TestListTelemetriesByProducer_ProducerWithMetrics(t *testing.T) {
 			LogSpanID:                 "",
 			LogEventName:              "",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 3,
@@ -235,6 +255,11 @@ func TestListTelemetriesByProducer_ProducerWithNoMetrics(t *testing.T) {
 			LogSpanID:                 "",
 			LogEventName:              "",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 1,
@@ -285,6 +310,11 @@ func TestListTelemetriesByProducer_ProducerWithLogRecords(t *testing.T) {
 			LogSpanID:                 "1234567890ABCDEF",
 			LogEventName:              "Reading CPU usage",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 10,
@@ -317,6 +347,11 @@ func TestListTelemetriesByProducer_ProducerWithLogRecords(t *testing.T) {
 			LogSpanID:                 "1234567890ABCDEF",
 			LogEventName:              "Reading Total Memory",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 5,
@@ -349,6 +384,11 @@ func TestListTelemetriesByProducer_ProducerWithLogRecords(t *testing.T) {
 			LogSpanID:                 "1234567890ABCDEF",
 			LogEventName:              "HTTP server requested",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 3,
@@ -409,6 +449,11 @@ func TestListTelemetriesByProducer_ProducerWithNoLogRecords(t *testing.T) {
 			LogSpanID:                 "1234567890ABCDEF",
 			LogEventName:              "Reading CPU usage",
 			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "",
+			SpanName:    "",
+			SpanID:      "",
+			SpanTraceID: "",
 			// Common fields
 			Protocol:  schema.TelemetryProtocolOTLP,
 			SeenCount: 10,
@@ -432,6 +477,200 @@ func TestListTelemetriesByProducer_ProducerWithNoLogRecords(t *testing.T) {
 
 	// Test: Get metrics for my-service v1.0.0
 	telemetries, err := repo.ListTelemetriesByProducer(ctx, "my-service", "2.0.0")
+
+	require.NoError(t, err)
+	require.Empty(t, telemetries)
+}
+
+func TestListTelemetriesByProducer_ProducerWithTraces(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert test data
+	testTelemetries := []schema.Telemetry{
+		{
+			SchemaID:      "trace1_schema_id",
+			SchemaKey:     "database-operation",
+			TelemetryType: schema.TelemetryTypeTrace,
+			// Metric fields
+			MetricType: schema.MetricTypeEmpty,
+			MetricUnit: "",
+			Brief:      "",
+			// Log fields
+			LogSeverityNumber:         0,
+			LogSeverityText:           "",
+			LogBody:                   "",
+			LogFlags:                  0,
+			LogTraceID:                "",
+			LogSpanID:                 "",
+			LogEventName:              "",
+			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "Server",
+			SpanName:    "database-operation",
+			SpanID:      "1234567890ABCDEF",
+			SpanTraceID: "1234567890ABCDEF1234567890ABCDEF",
+			// Common fields
+			Protocol:  schema.TelemetryProtocolOTLP,
+			SeenCount: 10,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Producers: map[string]*schema.Producer{
+				"producer1": {
+					Name:      "my-service",
+					Version:   "1.0.0",
+					Namespace: "default",
+					FirstSeen: time.Now(),
+					LastSeen:  time.Now(),
+				},
+			},
+		},
+		{
+			SchemaID:      "trace2_schema_id",
+			SchemaKey:     "http-request",
+			TelemetryType: schema.TelemetryTypeTrace,
+			// Metric fields
+			MetricType: schema.MetricTypeEmpty,
+			MetricUnit: "",
+			Brief:      "",
+			// Log fields
+			LogSeverityNumber:         0,
+			LogSeverityText:           "",
+			LogBody:                   "",
+			LogFlags:                  0,
+			LogTraceID:                "",
+			LogSpanID:                 "",
+			LogEventName:              "",
+			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "Client",
+			SpanName:    "http-request",
+			SpanID:      "1234567890ABCDEF",
+			SpanTraceID: "1234567890ABCDEF1234567890ABCDEF",
+			// Common fields
+			Protocol:  schema.TelemetryProtocolOTLP,
+			SeenCount: 5,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Producers: map[string]*schema.Producer{
+				"producer1": {
+					Name:      "my-service",
+					Version:   "1.0.0",
+					Namespace: "default",
+					FirstSeen: time.Now(),
+					LastSeen:  time.Now(),
+				},
+			},
+		},
+		{
+			SchemaID:      "trace3_schema_id",
+			SchemaKey:     "Random operation",
+			TelemetryType: schema.TelemetryTypeTrace,
+			// Metric fields
+			MetricType: schema.MetricTypeEmpty,
+			MetricUnit: "",
+			Brief:      "",
+			// Log fields
+			LogSeverityNumber:         0,
+			LogSeverityText:           "",
+			LogBody:                   "",
+			LogFlags:                  0,
+			LogTraceID:                "",
+			LogSpanID:                 "",
+			LogEventName:              "",
+			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "Server",
+			SpanName:    "Random operation",
+			SpanID:      "1234567890ABCDEF",
+			SpanTraceID: "1234567890ABCDEF1234567890ABCDEF",
+			// Common fields
+			Protocol:  schema.TelemetryProtocolOTLP,
+			SeenCount: 3,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Producers: map[string]*schema.Producer{
+				"producer2": {
+					Name:      "other-service",
+					Version:   "2.0.0",
+					Namespace: "default",
+					FirstSeen: time.Now(),
+					LastSeen:  time.Now(),
+				},
+			},
+		},
+	}
+
+	// Register test telemetries
+	err := repo.RegisterTelemetrySchemas(ctx, testTelemetries)
+	require.NoError(t, err)
+
+	// Test: Get metrics for my-service v1.0.0
+	telemetries, err := repo.ListTelemetriesByProducer(ctx, "my-service", "1.0.0")
+
+	require.NoError(t, err)
+	require.Len(t, telemetries, 2)
+
+	// Verify we got the right metrics
+	schemaKeys := make([]string, len(telemetries))
+	for i, t := range telemetries {
+		schemaKeys[i] = t.SchemaKey
+	}
+	require.Contains(t, schemaKeys, "database-operation")
+	require.Contains(t, schemaKeys, "http-request")
+	require.NotContains(t, schemaKeys, "Random operation")
+}
+
+func TestListTelemetriesByProducer_ProducerWithNoTraces(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert test data
+	testTelemetries := []schema.Telemetry{
+		{
+			SchemaID:      "trace1_schema_id",
+			SchemaKey:     "database-operation",
+			TelemetryType: schema.TelemetryTypeTrace,
+			// Metric fields
+			MetricType: schema.MetricTypeEmpty,
+			MetricUnit: "",
+			Brief:      "",
+			// Log fields
+			LogSeverityNumber:         0,
+			LogSeverityText:           "",
+			LogBody:                   "",
+			LogFlags:                  0,
+			LogTraceID:                "",
+			LogSpanID:                 "",
+			LogEventName:              "",
+			LogDroppedAttributesCount: 0,
+			// Span fields
+			SpanKind:    "Server",
+			SpanName:    "database-operation",
+			SpanID:      "1234567890ABCDEF",
+			SpanTraceID: "1234567890ABCDEF1234567890ABCDEF",
+			// Common fields
+			Protocol:  schema.TelemetryProtocolOTLP,
+			SeenCount: 10,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Producers: map[string]*schema.Producer{
+				"producer1": {
+					Name:      "my-service",
+					Version:   "1.0.0",
+					Namespace: "default",
+					FirstSeen: time.Now(),
+					LastSeen:  time.Now(),
+				},
+			},
+		},
+	}
+
+	err := repo.RegisterTelemetrySchemas(ctx, testTelemetries)
+	require.NoError(t, err)
+
+	// Test: Get telemetries for nonexistent-service v1.0.0
+	telemetries, err := repo.ListTelemetriesByProducer(ctx, "nonexistent-service", "1.0.0")
 
 	require.NoError(t, err)
 	require.Empty(t, telemetries)

--- a/internal/schema/attribute.go
+++ b/internal/schema/attribute.go
@@ -29,6 +29,7 @@ const (
 
 	AttributeSourceDataPoint AttributeSource = "DataPoint"
 	AttributeSourceLogRecord AttributeSource = "LogRecord"
+	AttributeSourceSpan      AttributeSource = "Span"
 )
 
 type Attribute struct {

--- a/internal/schema/schema_extractor.go
+++ b/internal/schema/schema_extractor.go
@@ -345,7 +345,7 @@ func ExtractFromTraces(traces ptrace.Traces) []Telemetry {
 
 				telemetry := Telemetry{
 					SchemaURL:     scopeSpan.SchemaUrl(),
-					TelemetryType: TelemetryTypeTrace,
+					TelemetryType: TelemetryTypeSpan,
 					SchemaKey:     span.Name(),
 					SpanKind:      SpanKind(span.Kind().String()),
 					SpanName:      span.Name(),

--- a/internal/schema/telemetry.go
+++ b/internal/schema/telemetry.go
@@ -30,11 +30,22 @@ const (
 	MetricTemporalityUnspecified MetricTemporality = "Unspecified"
 )
 
+type SpanKind string
+
+const (
+	SpanKindClient   SpanKind = "Client"
+	SpanKindServer   SpanKind = "Server"
+	SpanKindProducer SpanKind = "Producer"
+	SpanKindConsumer SpanKind = "Consumer"
+	SpanKindInternal SpanKind = "Internal"
+)
+
 type TelemetryType string
 
 const (
 	TelemetryTypeMetric TelemetryType = "Metric"
 	TelemetryTypeLog    TelemetryType = "Log"
+	TelemetryTypeTrace  TelemetryType = "Trace"
 )
 
 type Telemetry struct {
@@ -57,6 +68,11 @@ type Telemetry struct {
 	LogSpanID                 string `json:"logSpanID"`
 	LogEventName              string `json:"logEventName"`
 	LogDroppedAttributesCount int    `json:"logDroppedAttributesCount"`
+	// Span fields
+	SpanKind    SpanKind `json:"spanKind"`
+	SpanName    string   `json:"spanName"`
+	SpanID      string   `json:"spanID"`
+	SpanTraceID string   `json:"traceID"`
 
 	Attributes []Attribute       `json:"attributes"`
 	Note       string            `json:"note,omitempty"`

--- a/internal/schema/telemetry.go
+++ b/internal/schema/telemetry.go
@@ -45,7 +45,7 @@ type TelemetryType string
 const (
 	TelemetryTypeMetric TelemetryType = "Metric"
 	TelemetryTypeLog    TelemetryType = "Log"
-	TelemetryTypeTrace  TelemetryType = "Trace"
+	TelemetryTypeSpan   TelemetryType = "Span"
 )
 
 type Telemetry struct {

--- a/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
+++ b/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
@@ -90,7 +90,7 @@ export function TelemetryOverviewPanel({
               </>
             )}
 
-            {/* {telemetry.telemetryType === "trace" && telemetry.spanKind && (
+            {telemetry.telemetryType === "Trace" && telemetry.spanKind && (
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <Activity className="h-3.5 w-3.5 text-muted-foreground" />
@@ -98,7 +98,7 @@ export function TelemetryOverviewPanel({
                 </div>
                 <span className="text-sm">{telemetry.spanKind}</span>
               </div>
-            )} */}
+            )}
           </div>
         </div>
 

--- a/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
+++ b/ui/src/components/telemetry-catalog/features/telemetry/TelemetryOverviewPanel.tsx
@@ -90,7 +90,7 @@ export function TelemetryOverviewPanel({
               </>
             )}
 
-            {telemetry.telemetryType === "Trace" && telemetry.spanKind && (
+            {telemetry.telemetryType === "Span" && telemetry.spanKind && (
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <Activity className="h-3.5 w-3.5 text-muted-foreground" />

--- a/ui/src/components/telemetry-catalog/modals/SchemaDetailsModal.tsx
+++ b/ui/src/components/telemetry-catalog/modals/SchemaDetailsModal.tsx
@@ -89,7 +89,7 @@ export function SchemaDetailsModal({
               </TabsList>
 
               <TabsContent value="schema" className="mt-4">
-                <AttributesView attributes={viewingSchema.attributes} />
+                <AttributesView attributes={viewingSchema.attributes} telemetry={telemetry} />
               </TabsContent>
 
               <TabsContent value="producers" className="mt-4 space-y-4">

--- a/ui/src/components/telemetry/telemetry-card.tsx
+++ b/ui/src/components/telemetry/telemetry-card.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, Clock, Tag } from 'lucide-react'
+import { ChevronDown, Clock } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import {
   Card,
@@ -17,7 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import type { Telemetry } from '@/types/telemetry'
-import { DataTypeIcon } from './telemetry-icons'
+import { DataTypeIcon, getDataType } from './telemetry-icons'
 import { getTelemetryTypeBgColor, getStatusBadge } from '@/utils/telemetry'
 import { formatDate, DateFormat } from '@/lib/utils'
 
@@ -27,6 +27,7 @@ interface TelemetryCardProps {
 
 export const TelemetryCard = ({ item }: TelemetryCardProps) => {
   const statusBadge = getStatusBadge(undefined)
+  const dataType = getDataType(item)
 
   return (
     <Card className="overflow-hidden">
@@ -35,7 +36,7 @@ export const TelemetryCard = ({ item }: TelemetryCardProps) => {
           <div
             className={`flex h-8 w-8 items-center justify-center rounded-md ${getTelemetryTypeBgColor(item.telemetryType)}`}
           >
-            <DataTypeIcon dataType={item.metricType} />
+            <DataTypeIcon dataType={dataType} />
           </div>
           <CardTitle className="text-base">
             <Link
@@ -66,9 +67,9 @@ export const TelemetryCard = ({ item }: TelemetryCardProps) => {
         <div className="flex items-center justify-between py-1">
           <span className="text-sm text-muted-foreground">Type</span>
           <div className="flex items-center gap-1.5">
-            <DataTypeIcon dataType={item.metricType} />
+            <DataTypeIcon dataType={dataType} />
             <Badge variant="outline" className="capitalize">
-              {item.metricType}
+              {dataType}
             </Badge>
           </div>
         </div>

--- a/ui/src/components/telemetry/telemetry-icons.tsx
+++ b/ui/src/components/telemetry/telemetry-icons.tsx
@@ -11,7 +11,7 @@ import {
   ArrowUp,
   ArrowDown,
   Zap,
-  TreePine,
+  Logs,
 } from 'lucide-react'
 import { TelemetryType, type Telemetry } from '@/types/telemetry'
 
@@ -20,7 +20,7 @@ export const getDataType = (telemetry: Telemetry): string => {
   switch (telemetry.telemetryType) {
     case TelemetryType.Metric:
       return telemetry.metricType || ''
-    case TelemetryType.Trace:
+    case TelemetryType.Span:
       return telemetry.spanKind || ''
     case TelemetryType.Log:
       return 'log'
@@ -63,7 +63,7 @@ export const DataTypeIcon = ({ dataType }: { dataType: string }) => {
     case 'internal':
       return <Zap className="h-4 w-4 text-purple-400" />
     case 'log':
-      return <TreePine className="h-4 w-4 text-green-400" />
+      return <Logs className="h-4 w-4 text-green-400" />
     default:
       return <Code className="h-4 w-4 text-gray-400" />
   }
@@ -75,7 +75,7 @@ export const TelemetryTypeIcon = ({ type }: { type: TelemetryType }) => {
       return <BarChart3 className="h-5 w-5 text-blue-500" />
     case TelemetryType.Log:
       return <FileText className="h-5 w-5 text-green-500" />
-    case TelemetryType.Trace:
+    case TelemetryType.Span:
       return <Activity className="h-5 w-5 text-purple-500" />
     default:
       return <Code className="h-5 w-5 text-gray-500" />

--- a/ui/src/components/telemetry/telemetry-icons.tsx
+++ b/ui/src/components/telemetry/telemetry-icons.tsx
@@ -6,8 +6,28 @@ import {
   FileText,
   Activity,
   Code,
+  Server,
+  Smartphone,
+  ArrowUp,
+  ArrowDown,
+  Zap,
+  TreePine,
 } from 'lucide-react'
-import { TelemetryType } from '@/types/telemetry'
+import { TelemetryType, type Telemetry } from '@/types/telemetry'
+
+// Helper function to get the correct data type based on telemetry type
+export const getDataType = (telemetry: Telemetry): string => {
+  switch (telemetry.telemetryType) {
+    case TelemetryType.Metric:
+      return telemetry.metricType || ''
+    case TelemetryType.Trace:
+      return telemetry.spanKind || ''
+    case TelemetryType.Log:
+      return 'log'
+    default:
+      return ''
+  }
+}
 
 export const DataTypeIcon = ({ dataType }: { dataType: string }) => {
   if (!dataType) {
@@ -31,6 +51,19 @@ export const DataTypeIcon = ({ dataType }: { dataType: string }) => {
       return <FileText className="h-4 w-4 text-green-400" />
     case 'span':
       return <Activity className="h-4 w-4 text-purple-400" />
+    // Span kinds for traces
+    case 'server':
+      return <Server className="h-4 w-4 text-purple-400" />
+    case 'client':
+      return <Smartphone className="h-4 w-4 text-purple-400" />
+    case 'producer':
+      return <ArrowUp className="h-4 w-4 text-purple-400" />
+    case 'consumer':
+      return <ArrowDown className="h-4 w-4 text-purple-400" />
+    case 'internal':
+      return <Zap className="h-4 w-4 text-purple-400" />
+    case 'log':
+      return <TreePine className="h-4 w-4 text-green-400" />
     default:
       return <Code className="h-4 w-4 text-gray-400" />
   }

--- a/ui/src/routes/data-governance/telemetry-catalog.tsx
+++ b/ui/src/routes/data-governance/telemetry-catalog.tsx
@@ -425,7 +425,7 @@ export const SchemaCatalog = () => {
             <TabsTrigger value="all">All Telemetry</TabsTrigger>
             <TabsTrigger value="metric">Metrics</TabsTrigger>
             <TabsTrigger value="log">Logs</TabsTrigger>
-            <TabsTrigger value="trace">Traces</TabsTrigger>
+            <TabsTrigger value="span">Spans</TabsTrigger>
             <TabsTrigger value="profile">Profiles</TabsTrigger>
           </TabsList>
         </Tabs>

--- a/ui/src/routes/data-governance/telemetry-catalog.tsx
+++ b/ui/src/routes/data-governance/telemetry-catalog.tsx
@@ -17,7 +17,7 @@ import { TelemetryCard } from '@/components/telemetry/telemetry-card'
 import { DataTable } from '@/components/ui/data-table'
 import type { ViewMode, Telemetry } from '@/types/telemetry'
 import type { ColumnDef } from '@tanstack/react-table'
-import { DataTypeIcon } from '@/components/telemetry/telemetry-icons'
+import { DataTypeIcon, getDataType } from '@/components/telemetry/telemetry-icons'
 import { getTelemetryTypeBgColor } from '@/utils/telemetry'
 import { formatDate, DateFormat } from '@/lib/utils'
 import { Link } from '@tanstack/react-router'
@@ -40,7 +40,7 @@ const columns: ColumnDef<Telemetry>[] = [
               item.telemetryType,
             )}`}
           >
-            <DataTypeIcon dataType={item.metricType} />
+            <DataTypeIcon dataType={getDataType(item)} />
           </div>
           <div>
             <Link
@@ -73,10 +73,11 @@ const columns: ColumnDef<Telemetry>[] = [
     header: 'Data Type',
     cell: ({ row }) => {
       const item = row.original
+      const dataType = getDataType(item)
       return (
         <div className="flex items-center gap-1.5">
-          <DataTypeIcon dataType={item.metricType} />
-          <span className="text-sm">{item.metricType}</span>
+          <DataTypeIcon dataType={dataType} />
+          <span className="text-sm">{dataType}</span>
         </div>
       )
     },

--- a/ui/src/types/telemetry.ts
+++ b/ui/src/types/telemetry.ts
@@ -1,7 +1,7 @@
 export enum TelemetryType {
   Metric = 'Metric',
   Log = 'Log',
-  Trace = 'Trace',
+  Span = 'Span',
   Profile = 'Profile',
 }
 

--- a/ui/src/types/telemetry.ts
+++ b/ui/src/types/telemetry.ts
@@ -40,6 +40,11 @@ export interface Telemetry {
   logSpanID: string
   logEventName: string
   logDroppedAttributesCount: number
+  // Trace fields
+  spanKind: string
+  spanName: string
+  spanID: string
+  traceID: string
   // Common fields
   brief?: string
   note?: string

--- a/ui/src/utils/telemetry.ts
+++ b/ui/src/utils/telemetry.ts
@@ -6,7 +6,7 @@ export const getTelemetryTypeBgColor = (type: TelemetryType) => {
       return 'bg-blue-500/10'
     case TelemetryType.Log:
       return 'bg-green-500/10'
-    case TelemetryType.Trace:
+    case TelemetryType.Span:
       return 'bg-purple-500/10'
     default:
       return 'bg-gray-500/10'


### PR DESCRIPTION


- [X] Update `Telemetry` Go struct to support span-related fields.
- [x] Update Database table to support span-related fields.
- [X] Implement `ExtractFromTraces`, which transforms OTLP Traces into TallyCat's `Telemetry`.
- [x] Implement insertion of Spans into the database.
- [x] Implement API to request WeaverSchema from spans
