### PR TITLE
feat: add direct schema export

### DIFF
--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -91,6 +91,7 @@ func registerAPIRoutes(r chi.Router, srv *Server) {
 		})
 		r.Route("/producers", func(r chi.Router) {
 			r.Get("/{producerNameVersion}/weaver-schema.zip", api.HandleProducerWeaverSchemaExport(srv.schemaRepo))
+			r.Get("/{producerNameVersion}/{type}", api.HandleProducerSchemaExport(srv.schemaRepo))
 		})
 	})
 }


### PR DESCRIPTION
Took the zip export and split it into separate endpoints for the different telemetry types

Allows for easier sync with grafana as it avoids unzipping