### PR TITLE
Add Makefile & docker build cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+DOCKER_IMAGE_NAME := tallycat-hackathon
+DOCKER_IMAGE_TAG := 0.0.1
+
+
+.PHONY: build
+build:
+	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) .


### PR DESCRIPTION
Adds Makefile with a build target for local docker image

Useful for rapidly building and iterating on Tallycat for use within our Tilt/K3d environment.

`make build` builds `tallycat-hackathon:0.0.1` 