### PR TITLE
Add entity attributes to generated weaver schemas

### DIFF
--- a/internal/weaver/example_test.go
+++ b/internal/weaver/example_test.go
@@ -35,7 +35,7 @@ func ExampleGenerateYAML() {
 			{
 				Name:   "service.name",
 				Type:   schema.AttributeTypeStr,
-				Source: schema.AttributeSourceResource, // This will be filtered out
+				Source: schema.AttributeSourceResource,
 			},
 		},
 		Scope: &schema.Scope{
@@ -75,4 +75,9 @@ func ExampleGenerateYAML() {
 	//         requirement_level: recommended
 	//         stability: stable
 	//         brief: "HTTP response status code"
+	//       - id: service.name
+	//         type: string
+	//         requirement_level: recommended
+	//         stability: stable
+	//         brief: ""
 }

--- a/internal/weaver/generator.go
+++ b/internal/weaver/generator.go
@@ -83,7 +83,7 @@ func generateMetricYAML(telemetry *schema.Telemetry, telemetrySchema *schema.Tel
 
 	// Filter for DataPoint source attributes
 	for _, attr := range attributesToUse {
-		if attr.Source == schema.AttributeSourceDataPoint {
+		if attr.Source == schema.AttributeSourceDataPoint || attr.Source == schema.AttributeSourceResource || attr.Source == schema.AttributeSourceScope {
 			dataPointAttributes = append(dataPointAttributes, attr)
 		}
 	}
@@ -133,7 +133,7 @@ func generateLogEventYAML(telemetry *schema.Telemetry, telemetrySchema *schema.T
 
 	// Filter for LogRecord source attributes
 	for _, attr := range attributesToUse {
-		if attr.Source == schema.AttributeSourceLogRecord {
+		if attr.Source == schema.AttributeSourceLogRecord || attr.Source == schema.AttributeSourceResource || attr.Source == schema.AttributeSourceScope {
 			allAttributes = append(allAttributes, attr)
 		}
 	}
@@ -182,7 +182,7 @@ func generateSpanYAML(telemetry *schema.Telemetry, telemetrySchema *schema.Telem
 
 	// Filter for Span source attributes (span-level attributes)
 	for _, attr := range attributesToUse {
-		if attr.Source == schema.AttributeSourceSpan {
+		if attr.Source == schema.AttributeSourceSpan || attr.Source == schema.AttributeSourceResource || attr.Source == schema.AttributeSourceScope {
 			spanAttributes = append(spanAttributes, attr)
 		}
 	}

--- a/internal/weaver/generator_test.go
+++ b/internal/weaver/generator_test.go
@@ -81,9 +81,9 @@ func TestGenerateYAML_BasicTelemetry(t *testing.T) {
 		}
 	}
 
-	// Verify that resource attributes are filtered out
-	if strings.Contains(yaml, "service.name") {
-		t.Error("YAML should not contain resource attributes")
+	// Verify that resource attributes are now included
+	if !strings.Contains(yaml, "service.name") {
+		t.Error("YAML should contain resource attributes")
 	}
 }
 
@@ -150,9 +150,17 @@ func TestGenerateYAML_NoDataPointAttributes(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Should NOT contain an attributes section when there are no DataPoint attributes
-	if strings.Contains(yaml, "attributes:") {
-		t.Error("YAML should not contain attributes section when there are no DataPoint attributes")
+	// Should contain attributes section with resource and scope attributes
+	if !strings.Contains(yaml, "attributes:") {
+		t.Error("YAML should contain attributes section with resource and scope attributes")
+	}
+
+	// Should contain resource and scope attributes
+	if !strings.Contains(yaml, "service.name") {
+		t.Error("YAML should contain resource attributes")
+	}
+	if !strings.Contains(yaml, "library.name") {
+		t.Error("YAML should contain scope attributes")
 	}
 
 	// Should not contain the old comment
@@ -635,9 +643,9 @@ func TestGenerateYAML_LogEvent_BasicTelemetry(t *testing.T) {
 		}
 	}
 
-	// Verify that resource attributes are filtered out
-	if strings.Contains(yaml, "service.name") {
-		t.Error("YAML should not contain resource attributes")
+	// Verify that resource attributes are now included
+	if !strings.Contains(yaml, "service.name") {
+		t.Error("YAML should contain resource attributes")
 	}
 }
 


### PR DESCRIPTION
cc @theSuess 

I can see the entity attributes in the schemas. Is that what you need for your dashboards?
<img width="566" height="1024" alt="image" src="https://github.com/user-attachments/assets/e716b77d-2766-47de-80de-c82b48cc9e40" />
